### PR TITLE
Fix SchleuderResend script after conversion to WebExtension API

### DIFF
--- a/scripts/SchleuderResend.mjs
+++ b/scripts/SchleuderResend.mjs
@@ -25,9 +25,14 @@ export async function SchleuderResend() {
         emails = emails.map(sanitizeMail)
 
         for (let email in emails) {
-            resentEmails.push("x-resend: ".concat(emails[email]))
+            resentEmails.push("X-RESEND: ".concat(emails[email]))
         }
     }
+
+    if (headerLines.length == 0) {
+        resentEmails.push("X-RESEND: ")
+    }
+
     return resentEmails.join("\n")
 
     function sanitizeMail(value) {

--- a/scripts/SchleuderResend.mjs
+++ b/scripts/SchleuderResend.mjs
@@ -1,12 +1,10 @@
 export async function SchleuderResend() {
-    let { relatedMessageId } = await this.compose.getComposeDetails();
-    // Instead of parsing the raw message for headers, better use getFull to get the individual parsed headers.
-    let text = await this.messages.getRaw(relatedMessageId).then(t => t.replaceAll("\r\n", "\n"));
+    let { plainTextBody } = await this.compose.getComposeDetails()
 
-    let resentLines = text.match(/Resent: .*\n/g)
-    let fromLines = text.match(/From: .*\n/g)
-    let toLines = text.match(/To: .*\n/g)
-    let ccLines = text.match(/Cc: .*\n/g)
+    let resentLines = plainTextBody.match(/Resent: (.*)\n/)
+    let fromLines = plainTextBody.match(/From: .*\n/g)
+    let toLines = plainTextBody.match(/To: .*\n/g)
+    let ccLines = plainTextBody.match(/Cc: .*\n/g)
 
     let headerLines = []
 


### PR DESCRIPTION
* [fix(SchleuderResend): Fix parsing body of compose message](https://github.com/jobisoft/quicktext-community-scripts/commit/571c78e62be4b2f69060592fcc7e3d5d17ce1cd5)
* [fix(SchleuderResend): Always return a 'X-RESEND' pseudo header](https://github.com/jobisoft/quicktext-community-scripts/commit/a5beb86934649daacb4d1166d6a75c2cd1beefb4)